### PR TITLE
chore: add commit-msg commit validation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # sociallink
+
+## Conventional commits
+
+This project follows conventional commits. Read more about it [here](https://www.conventionalcommits.org/en/v1.0.0/). Run `scripts/init-repo.sh` to set up the commit validation hook.
+

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Description: A simple script to lint commit messages
+
+set -e
+set -o pipefail
+
+COMMIT_MESSAGE=$(cat $1 | head -n 1) 
+# Check if commit message starts with valid prefix and optional scope () and a colon
+# If it does, exit with a success message
+# If it doesn't, exit with an error message
+# Valid prefixes are: feat, fix, docs, style, refactor, test, chore
+
+REGEXP='^(feat|fix|docs|style|refactor|test|chore)(\([a-z]+\))?:\s[a-z]([a-zA-Z0-9-]|\s)+$'
+
+if [[ "$COMMIT_MESSAGE" =~ $REGEXP ]]; then
+  exit 0
+else
+  echo "Commit message is invalid: $COMMIT_MESSAGE. It should start with a valid prefix and optional scope in parentheses"
+  echo "Valid prefixes are: feat, fix, docs, style, refactor, test, chore"
+  exit 1
+fi
+
+

--- a/scripts/init-repo.sh
+++ b/scripts/init-repo.sh
@@ -1,0 +1,1 @@
+git config core.hooksPath hooks


### PR DESCRIPTION
Add commit-msg hook to help us write commit messages following the conventional commit message standard.