### PR TITLE
feat: login functionality

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -30,16 +30,16 @@ func main() {
 
 			fmt.Printf("\n%s %s\n", email, password)
 
-			record, err := app.Dao().FindAuthRecordByEmail("users", email)
+			authRecord, err := app.Dao().FindAuthRecordByEmail("users", email)
 			if err != nil {
 				return err
 			}
 
-			if !record.ValidatePassword(password) {
+			if !authRecord.ValidatePassword(password) {
 				return c.HTML(http.StatusUnauthorized, "401 - Unauthorized")
 			}
 
-			token, tokenErr := tokens.NewRecordAuthToken(app, record)
+			token, tokenErr := tokens.NewRecordAuthToken(app, authRecord)
 			if tokenErr != nil {
 				return c.HTML(http.StatusInternalServerError, "500 - Internal Server Error")
 			}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -2,139 +2,23 @@ package main
 
 import (
 	"log"
-	"net/http"
 	"os"
 
-	"github.com/labstack/echo/v5"
+	"github.com/namatoj/sociallink/pkg/web"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tokens"
-	"github.com/pocketbase/pocketbase/tools/security"
-	"github.com/spf13/cast"
 )
-
-func loadAuthContextFromCookie(app core.App) echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			tokenCookie, err := c.Request().Cookie("token")
-			if err != nil || tokenCookie.Value == "" {
-				return next(c) // no token cookie
-			}
-
-			token := tokenCookie.Value
-
-			claims, _ := security.ParseUnverifiedJWT(token)
-			tokenType := cast.ToString(claims["type"])
-
-			switch tokenType {
-			case tokens.TypeAdmin:
-				admin, err := app.Dao().FindAdminByToken(
-					token,
-					app.Settings().AdminAuthToken.Secret,
-				)
-				if err == nil && admin != nil {
-					// "authenticate" the admin
-					c.Set(apis.ContextAdminKey, admin)
-				}
-			case tokens.TypeAuthRecord:
-				record, err := app.Dao().FindAuthRecordByToken(
-					token,
-					app.Settings().RecordAuthToken.Secret,
-				)
-				if err == nil && record != nil {
-					// "authenticate" the app user
-					c.Set(apis.ContextAuthRecordKey, record)
-				}
-			}
-
-			return next(c)
-		}
-	}
-}
 
 func main() {
 	app := pocketbase.New()
 
-	// serves static files from the provided public dir (if exists)
 	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+		e.Router.Use(web.LoadAuthContextFromCookie(app))
 		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS("./pb_public"), false))
-		return nil
-	})
-
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
-		e.Router.Use(loadAuthContextFromCookie(app))
-		return nil
-	})
-
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
-		e.Router.POST("/login/", func(c echo.Context) error {
-			email := c.FormValue("email")
-			password := c.FormValue("password")
-
-			authRecord, err := app.Dao().FindAuthRecordByEmail("users", email)
-			if err != nil {
-				return err
-			}
-
-			if !authRecord.ValidatePassword(password) {
-				return c.HTML(http.StatusUnauthorized, "401 - Unauthorized")
-			}
-
-			token, tokenErr := tokens.NewRecordAuthToken(app, authRecord)
-			if tokenErr != nil {
-				return c.HTML(http.StatusInternalServerError, "500 - Internal Server Error")
-			}
-
-			c.SetCookie(&http.Cookie{
-				Name:     "token",
-				Value:    token,
-				Path:     "/",
-				Secure:   true,
-				HttpOnly: true,
-				SameSite: http.SameSiteLaxMode,
-			})
-
-			return c.HTML(http.StatusOK, "/login/")
-		})
-
-		return nil
-	})
-
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
-		e.Router.GET("/", func(c echo.Context) error {
-			info := apis.RequestInfo(c)
-			admin := info.Admin       // nil if not authenticated as admin
-			record := info.AuthRecord // nil if not authenticated as regular auth record
-
-			isGuest := admin == nil && record == nil
-
-			if isGuest {
-				return c.HTML(http.StatusOK, "not logged in")
-
-			}
-
-			return c.HTML(http.StatusOK, "logged in")
-
-		})
-
-		return nil
-	})
-
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
-		e.Router.GET("/logout/", func(c echo.Context) error {
-			c.SetCookie(&http.Cookie{
-				Name:     "token",
-				Value:    "",
-				Path:     "/",
-				MaxAge:   -1,
-				Secure:   true,
-				HttpOnly: true,
-			})
-
-			return c.HTML(http.StatusOK, "logged out")
-		})
-
+		e.Router.POST("/login/", web.LoginHandler(app))
+		e.Router.GET("/logout/", web.LogoutHandler)
+		e.Router.GET("/", web.RootHandler)
 		return nil
 	})
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -24,11 +23,8 @@ func main() {
 
 	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
 		e.Router.POST("/login/", func(c echo.Context) error {
-			// data := apis.RequestInfo(c).Data
 			email := c.FormValue("email")
 			password := c.FormValue("password")
-
-			fmt.Printf("\n%s %s\n", email, password)
 
 			authRecord, err := app.Dao().FindAuthRecordByEmail("users", email)
 			if err != nil {
@@ -43,7 +39,6 @@ func main() {
 			if tokenErr != nil {
 				return c.HTML(http.StatusInternalServerError, "500 - Internal Server Error")
 			}
-			fmt.Printf("%v\n", token)
 
 			c.SetCookie(&http.Cookie{
 				Name:     "token",

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -45,6 +45,15 @@ func main() {
 			}
 			fmt.Printf("%v\n", token)
 
+			c.SetCookie(&http.Cookie{
+				Name:     "token",
+				Value:    token,
+				Path:     "/",
+				Secure:   true,
+				HttpOnly: true,
+				SameSite: http.SameSiteLaxMode,
+			})
+
 			return c.HTML(http.StatusOK, "/login")
 		})
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -121,6 +121,23 @@ func main() {
 		return nil
 	})
 
+	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+		e.Router.GET("/logout/", func(c echo.Context) error {
+			c.SetCookie(&http.Cookie{
+				Name:     "token",
+				Value:    "",
+				Path:     "/",
+				MaxAge:   -1,
+				Secure:   true,
+				HttpOnly: true,
+			})
+
+			return c.HTML(http.StatusOK, "logged out")
+		})
+
+		return nil
+	})
+
 	if err := app.Start(); err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -2,25 +2,12 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/namatoj/sociallink/pkg/web"
-	"github.com/pocketbase/pocketbase"
-	"github.com/pocketbase/pocketbase/apis"
-	"github.com/pocketbase/pocketbase/core"
 )
 
 func main() {
-	app := pocketbase.New()
-
-	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
-		e.Router.Use(web.LoadAuthContextFromCookie(app))
-		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS("./pb_public"), false))
-		e.Router.POST("/login/", web.LoginHandler(app))
-		e.Router.GET("/logout/", web.LogoutHandler)
-		e.Router.GET("/", web.RootHandler)
-		return nil
-	})
+	app := web.App()
 
 	if err := app.Start(); err != nil {
 		log.Fatal(err)

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -10,7 +10,48 @@ import (
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tokens"
+	"github.com/pocketbase/pocketbase/tools/security"
+	"github.com/spf13/cast"
 )
+
+func loadAuthContextFromCookie(app core.App) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			tokenCookie, err := c.Request().Cookie("token")
+			if err != nil || tokenCookie.Value == "" {
+				return next(c) // no token cookie
+			}
+
+			token := tokenCookie.Value
+
+			claims, _ := security.ParseUnverifiedJWT(token)
+			tokenType := cast.ToString(claims["type"])
+
+			switch tokenType {
+			case tokens.TypeAdmin:
+				admin, err := app.Dao().FindAdminByToken(
+					token,
+					app.Settings().AdminAuthToken.Secret,
+				)
+				if err == nil && admin != nil {
+					// "authenticate" the admin
+					c.Set(apis.ContextAdminKey, admin)
+				}
+			case tokens.TypeAuthRecord:
+				record, err := app.Dao().FindAuthRecordByToken(
+					token,
+					app.Settings().RecordAuthToken.Secret,
+				)
+				if err == nil && record != nil {
+					// "authenticate" the app user
+					c.Set(apis.ContextAuthRecordKey, record)
+				}
+			}
+
+			return next(c)
+		}
+	}
+}
 
 func main() {
 	app := pocketbase.New()
@@ -18,6 +59,11 @@ func main() {
 	// serves static files from the provided public dir (if exists)
 	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
 		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS("./pb_public"), false))
+		return nil
+	})
+
+	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+		e.Router.Use(loadAuthContextFromCookie(app))
 		return nil
 	})
 
@@ -49,7 +95,27 @@ func main() {
 				SameSite: http.SameSiteLaxMode,
 			})
 
-			return c.HTML(http.StatusOK, "/login")
+			return c.HTML(http.StatusOK, "/login/")
+		})
+
+		return nil
+	})
+
+	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+		e.Router.GET("/", func(c echo.Context) error {
+			info := apis.RequestInfo(c)
+			admin := info.Admin       // nil if not authenticated as admin
+			record := info.AuthRecord // nil if not authenticated as regular auth record
+
+			isGuest := admin == nil && record == nil
+
+			if isGuest {
+				return c.HTML(http.StatusOK, "not logged in")
+
+			}
+
+			return c.HTML(http.StatusOK, "logged in")
+
 		})
 
 		return nil

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"log"
+	"net/http"
 	"os"
 
+	"github.com/labstack/echo/v5"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
@@ -15,6 +17,19 @@ func main() {
 	// serves static files from the provided public dir (if exists)
 	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
 		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS("./pb_public"), false))
+		return nil
+	})
+
+	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+		e.Router.POST("/login/", func(c echo.Context) error {
+			// data := apis.RequestInfo(c).Data
+			email := c.FormValue("email")
+			password := c.FormValue("password")
+			print(email, password)
+
+			return c.HTML(http.StatusOK, "/login")
+		})
+
 		return nil
 	})
 

--- a/pkg/web/app.go
+++ b/pkg/web/app.go
@@ -34,7 +34,6 @@ func RootHandler(c echo.Context) error {
 
 	if isGuest {
 		return c.HTML(http.StatusOK, "not logged in")
-
 	}
 
 	return c.HTML(http.StatusOK, "logged in")

--- a/pkg/web/app.go
+++ b/pkg/web/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/spf13/cast"
 )
 
 func App() *pocketbase.PocketBase {
@@ -26,11 +27,8 @@ func App() *pocketbase.PocketBase {
 }
 
 func RootHandler(c echo.Context) error {
-	info := apis.RequestInfo(c)
-	admin := info.Admin       // nil if not authenticated as admin
-	record := info.AuthRecord // nil if not authenticated as regular auth record
-
-	isGuest := admin == nil && record == nil
+	isGuestRaw := c.Get(ContextAuthIsGuestKey)
+	isGuest := cast.ToBool(isGuestRaw)
 
 	if isGuest {
 		return c.HTML(http.StatusOK, "not logged in")

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -1,0 +1,98 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tokens"
+	"github.com/pocketbase/pocketbase/tools/security"
+	"github.com/spf13/cast"
+)
+
+func LoginHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		email := c.FormValue("email")
+		password := c.FormValue("password")
+
+		authRecord, err := app.Dao().FindAuthRecordByEmail("users", email)
+		if err != nil {
+			return err
+		}
+
+		if !authRecord.ValidatePassword(password) {
+			return c.HTML(http.StatusUnauthorized, "401 - Unauthorized")
+		}
+
+		token, tokenErr := tokens.NewRecordAuthToken(app, authRecord)
+		if tokenErr != nil {
+			return c.HTML(http.StatusInternalServerError, "500 - Internal Server Error")
+		}
+
+		c.SetCookie(&http.Cookie{
+			Name:     "token",
+			Value:    token,
+			Path:     "/",
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
+
+		return c.HTML(http.StatusOK, "/login/")
+	}
+}
+
+func LogoutHandler(c echo.Context) error {
+	c.SetCookie(&http.Cookie{
+		Name:     "token",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Secure:   true,
+		HttpOnly: true,
+	})
+
+	return c.HTML(http.StatusOK, "logged out")
+
+}
+
+func LoadAuthContextFromCookie(app core.App) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			tokenCookie, err := c.Request().Cookie("token")
+			if err != nil || tokenCookie.Value == "" {
+				return next(c) // no token cookie
+			}
+
+			token := tokenCookie.Value
+
+			claims, _ := security.ParseUnverifiedJWT(token)
+			tokenType := cast.ToString(claims["type"])
+
+			switch tokenType {
+			case tokens.TypeAdmin:
+				admin, err := app.Dao().FindAdminByToken(
+					token,
+					app.Settings().AdminAuthToken.Secret,
+				)
+				if err == nil && admin != nil {
+					// "authenticate" the admin
+					c.Set(apis.ContextAdminKey, admin)
+				}
+			case tokens.TypeAuthRecord:
+				record, err := app.Dao().FindAuthRecordByToken(
+					token,
+					app.Settings().RecordAuthToken.Secret,
+				)
+				if err == nil && record != nil {
+					// "authenticate" the app user
+					c.Set(apis.ContextAuthRecordKey, record)
+				}
+			}
+
+			return next(c)
+		}
+	}
+}

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -55,7 +55,6 @@ func LogoutHandler(c echo.Context) error {
 	})
 
 	return c.HTML(http.StatusOK, "logged out")
-
 }
 
 func LoadAuthContextFromCookie(app core.App) echo.MiddlewareFunc {

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -23,7 +23,7 @@ func LoginHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 
 		authRecord, err := app.Dao().FindAuthRecordByEmail("users", email)
 		if err != nil {
-			return err
+			return c.HTML(http.StatusUnauthorized, "401 - Unauthorized")
 		}
 
 		if !authRecord.ValidatePassword(password) {

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -12,6 +12,10 @@ import (
 	"github.com/spf13/cast"
 )
 
+const (
+	ContextAuthIsGuestKey string = "isGuest"
+)
+
 func LoginHandler(app *pocketbase.PocketBase) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		email := c.FormValue("email")
@@ -62,6 +66,7 @@ func LoadAuthContextFromCookie(app core.App) echo.MiddlewareFunc {
 		return func(c echo.Context) error {
 			tokenCookie, err := c.Request().Cookie("token")
 			if err != nil || tokenCookie.Value == "" {
+				c.Set(ContextAuthIsGuestKey, true)
 				return next(c) // no token cookie
 			}
 

--- a/pkg/web/start.go
+++ b/pkg/web/start.go
@@ -1,0 +1,23 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase/apis"
+)
+
+func RootHandler(c echo.Context) error {
+	info := apis.RequestInfo(c)
+	admin := info.Admin       // nil if not authenticated as admin
+	record := info.AuthRecord // nil if not authenticated as regular auth record
+
+	isGuest := admin == nil && record == nil
+
+	if isGuest {
+		return c.HTML(http.StatusOK, "not logged in")
+
+	}
+
+	return c.HTML(http.StatusOK, "logged in")
+}

--- a/pkg/web/start.go
+++ b/pkg/web/start.go
@@ -2,10 +2,28 @@ package web
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
 )
+
+func App() *pocketbase.PocketBase {
+	app := pocketbase.New()
+
+	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
+		e.Router.Use(LoadAuthContextFromCookie(app))
+		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS("./pb_public"), false))
+		e.Router.POST("/login/", LoginHandler(app))
+		e.Router.GET("/logout/", LogoutHandler)
+		e.Router.GET("/", RootHandler)
+		return nil
+	})
+
+	return app
+}
 
 func RootHandler(c echo.Context) error {
 	info := apis.RequestInfo(c)


### PR DESCRIPTION
Added functionality to use the JWT in a session cookie as mentioned [here](https://github.com/namatoj/sociallink/issues/2)

Added the following routes:
- /
- /login/
- /logout/

If sending a POST request to `/login/` containing the form-data values `email` and `password` while it is served using https corresponding to a user in the user collection the cookie `token` will be set.

@simondmansson I'm a bit unsure about how we want to structure the routes and the middleware function. It quite fast became rather messy. :-) I'm open for suggestions. Othewise I will leave this PR for a bit and come back when I have more inspiration for structure.